### PR TITLE
Use LDADD instead if LIBADD

### DIFF
--- a/ctm/Makefile
+++ b/ctm/Makefile
@@ -11,7 +11,7 @@ PROG=	ctm
 SRCS=  	ctm.c ctm_input.c ctm_pass1.c ctm_pass2.c ctm_pass3.c \
 	ctm_passb.c ctm_syntax.c ctm_ed.c
 
-LIBADD=	md
+LDADD=	-l md
 
 WARNS?=	2
 

--- a/mkCTM/Makefile
+++ b/mkCTM/Makefile
@@ -3,7 +3,7 @@
 PROG=	mkctm
 MAN=
 
-LIBADD=	md
+LDADD=	-l md
 
 test:	mkctm
 	rm -f tst.out*


### PR DESCRIPTION
Linking with libmd requires use of LDADD for FreeBSD-11.2 and earlier - LDADD works with all versions.